### PR TITLE
Fix: 이미지 슬라이더 관련 워닝 해결

### DIFF
--- a/src/components/ProductImage/ProductImage.js
+++ b/src/components/ProductImage/ProductImage.js
@@ -36,12 +36,8 @@ function ProductImage() {
       <StyledSlider {...settings}>
         {image?.map((img, idx) => {
           return (
-            <CardBox>
-              <CardImg
-                alt="productImg"
-                src={img.product_images}
-                key={img.product_images + idx}
-              />
+            <CardBox key={idx}>
+              <CardImg alt="productImg" src={img.product_images} />
             </CardBox>
           );
         })}


### PR DESCRIPTION
## :: 최근 작업 주제

- [ ] 레이아웃 구현
- [ ] 기능 추가
- [ ] 리뷰 반영
- [X] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표

- 이미지 슬라이더 관련 워닝 해결

<br />

## :: 구현 사항 설명

1. 이미지 슬라이더 관련 워닝 해결

- key가 map이 돌려지는 최상위 요소가 아닌 하위 요소에 존재하고
있었고, warning이 발생했습니다. key를 map이 돌려지는 최상위
요소로 이동시킴으로써 문제를 해결했습니다.

<br />

## :: 성장 포인트

- 리액트에서 map과 key에 대한 이해를 높일 수 있었습니다.

<br />

## :: 기타 질문 및 특이 사항

- 없음
